### PR TITLE
Synchronisiert mit Main

### DIFF
--- a/Make/VSCode/default_settings/settings.json
+++ b/Make/VSCode/default_settings/settings.json
@@ -1,4 +1,5 @@
 {
+    "terminal.integrated.env.linux": { "GTK_PATH": null }   
     "git.ignoreLimitWarning": true,
     //"editor.formatOnSave": true,
     "files.associations": {

--- a/Make/VSCode/default_settings/tasks.json
+++ b/Make/VSCode/default_settings/tasks.json
@@ -74,7 +74,7 @@
             "options": {
                 "statusbar": {
                     "hide" : false,
-                    "color": "#000000",
+                    "color": "#888888",
                     "label": "bush"
                 }
             }
@@ -92,7 +92,7 @@
                 "statusbar": {
                     "hide" : false,
                     "color": "#fbff00",
-                    "label": "Sim"
+                    "label": "SimRobot Release"
                 }
             }
         },
@@ -109,7 +109,24 @@
                 "statusbar": {
                     "hide" : false,
                     "color": "#fbff00",
-                    "label": "Sim Dev"
+                    "label": "SimRobot Develop"
+                }
+            }
+        },
+
+        {
+            "label": "Sim Debug",
+            "type": "shell",
+            "command": "${workspaceFolder}/Build/Linux/SimRobot/Debug/SimRobot",
+            "dependsOn": "build sim debug",
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "options": {
+                "statusbar": {
+                    "hide" : false,
+                    "color": "#fbff00",
+                    "label": "SimRobot Debug"
                 }
             }
         },
@@ -124,27 +141,6 @@
             ],
             "group": {
                 "kind": "build"
-            }
-        },
-
-        {
-            "label": "build nao develop",
-            "type": "shell",
-            "command": "${workspaceFolder}/Make/Linux/compile Nao Develop",
-            "dependsOn": "generate ninja project",
-            "problemMatcher": [
-                "$gcc"
-            ],
-            "group": {
-                "kind": "build"
-            }, 
-
-            "options": {
-                "statusbar": {
-                    "hide" : false,
-                    "color": "#0ad41b",
-                    "label": "Build Nao Dev"
-                }
             }
         },
 
@@ -164,7 +160,49 @@
                 "statusbar": {
                     "hide" : false,
                     "color": "#0ad41b",
-                    "label": "Build Nao"
+                    "label": "Build Nao Release"
+                }
+            }
+        },
+
+        {
+            "label": "build nao develop",
+            "type": "shell",
+            "command": "${workspaceFolder}/Make/Linux/compile Nao Develop",
+            "dependsOn": "generate ninja project",
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind": "build"
+            }, 
+
+            "options": {
+                "statusbar": {
+                    "hide" : false,
+                    "color": "#0ad41b",
+                    "label": "Build Nao Develop"
+                }
+            }
+        },
+
+        {
+            "label": "build nao debug",
+            "type": "shell",
+            "command": "${workspaceFolder}/Make/Linux/compile Nao Debug",
+            "dependsOn": "generate ninja project",
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind": "build"
+            }, 
+
+            "options": {
+                "statusbar": {
+                    "hide" : false,
+                    "color": "#0ad41b",
+                    "label": "Build Nao Debug"
                 }
             }
         },

--- a/Src/Tools/Streams/TypeRegistry.cpp
+++ b/Src/Tools/Streams/TypeRegistry.cpp
@@ -10,6 +10,7 @@
  * @author Thomas Röfer
  */
 
+#include <cstring>
 #include <cctype>
 #ifndef WINDOWS
 #include <cstdlib>

--- a/Src/Tools/Streams/TypeRegistry.cpp
+++ b/Src/Tools/Streams/TypeRegistry.cpp
@@ -10,7 +10,6 @@
  * @author Thomas Röfer
  */
 
-#include <cstring>
 #include <cctype>
 #ifndef WINDOWS
 #include <cstdlib>


### PR DESCRIPTION
This pull request updates the default VSCode settings and build tasks to improve clarity and usability, especially around build and run configurations for the SimRobot and Nao projects. The changes mainly clarify task labels, add new build/run tasks, and tweak environment and UI settings.

**VSCode Task and Status Bar Improvements:**

* Added a new "Sim Debug" task to run the SimRobot Debug build, including a distinct status bar label and color.
* Clarified and updated labels for SimRobot tasks: changed "Sim" to "SimRobot Release", and "Sim Dev" to "SimRobot Develop" for better distinction. [[1]](diffhunk://#diff-5b19f49d21912bcba994237615ebd95d67e11a8905bfe4647f04941883d986fcL95-R95) [[2]](diffhunk://#diff-5b19f49d21912bcba994237615ebd95d67e11a8905bfe4647f04941883d986fcL112-R129)
* Changed the status bar color for the "bush" task from black to gray for improved visibility.

**Nao Build Task Enhancements:**

* Added a new "build nao release" task for building the Nao Release configuration, with a clear status bar label and color.
* Renamed "Build Nao Dev" to "Build Nao Develop" and updated the corresponding label for consistency.
* Changed the "build nao release" task to "build nao debug" and updated its command and status bar label to match the debug configuration. [[1]](diffhunk://#diff-5b19f49d21912bcba994237615ebd95d67e11a8905bfe4647f04941883d986fcL146-R192) [[2]](diffhunk://#diff-5b19f49d21912bcba994237615ebd95d67e11a8905bfe4647f04941883d986fcL167-R205)

**General Settings Update:**

* Added a setting to the integrated terminal environment on Linux to set `GTK_PATH` to `null`, which may help avoid environment-related issues.